### PR TITLE
[] fix lru cache import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.4"
   - "3.5"
+  - "3.8"
 install:
   - pip install -U pip
   - pip install coveralls isort flake8

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ pip install dev-requirements.txt && py.tets --cov
 
 # Compatibility
 
-* Django >= 2.0
-* Django Rest Framework >= 3.7
+* Django >= 3.2.11
+* Django Rest Framework >= 3.12.2
 
 # License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-django==2.0.2
+django==3.2.11
 djangorestframework-jwt==1.11.0
-djangorestframework==3.7.7
+djangorestframework==3.12.2
 pyjwt==1.5.3              # via djangorestframework-jwt
 pytz==2018.3              # via django

--- a/rest_jwt_permission/apps.py
+++ b/rest_jwt_permission/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 
 class RestApiPermissionConfig(AppConfig):
-    name = 'rest_api_permission'
+    name = 'rest_jwt_permission'

--- a/rest_jwt_permission/providers/admin.py
+++ b/rest_jwt_permission/providers/admin.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
-from django.utils.lru_cache import lru_cache
+import django
+
+if django.VERSION < (3, 0):
+    from django.utils.lru_cache import lru_cache
+else:
+    from functools import lru_cache
+
 from django.utils.translation import ugettext_lazy as _
 
 from .base import ScopeProviderBase

--- a/rest_jwt_permission/providers/api_endpoint.py
+++ b/rest_jwt_permission/providers/api_endpoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.utils.lru_cache import lru_cache
+from functools import lru_cache
 from rest_framework.schemas.generators import EndpointEnumerator
 
 from rest_jwt_permission.utils import get_role_for, get_view_role

--- a/setup.py
+++ b/setup.py
@@ -7,19 +7,19 @@ except IOError:
     long_description = ""
 
 setup(
-    name="rest-jwt-permission",
-    version="1.0.0",
-    description="Django Rest Framework JWT Permissions",
+    name="django3-rest-jwt-permission",
+    version="1.0.1",
+    description="Django3 Rest Framework JWT Permissions",
     license="MIT",
-    author="Christian Hess",
-    author_email="christianhess.rlz@gmail.com",
+    author="Rati Matchavariani",
+    author_email="rati.matchavariani@hellotend.com",
     packages=find_packages(),
     install_requires=[],
     long_description=long_description,
-    url="https://github.com/chessbr/rest-jwt-permission",
+    url="https://github.com/tend/rest-jwt-permission",
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.8",
         "Environment :: Web Environment",
         "Topic :: Internet :: WWW/HTTP",
         "Intended Audience :: Developers"

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     packages=find_packages(),
     install_requires=[],
     long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/tend/rest-jwt-permission",
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
When I run `python manage.py show_roles` I get `ModuleNotFoundError: No module named 'django.utils.lru_cache'`. This fix is similar to what crispy forms are doing for retro compatibility.

Original PR:

https://github.com/django-crispy-forms/django-crispy-forms/blob/23364c25fcd0c47fa8b0dd15f3054772eae7466e/crispy_forms/compatibility.py

Haven't tested it though, but the solution should be a long the lines.